### PR TITLE
SDHC support, reverse keypad x y direction and SD print progress display

### DIFF
--- a/LCDKeypad.h
+++ b/LCDKeypad.h
@@ -18,6 +18,7 @@
 
 #ifdef HAS_SD
 #include "SDCard.h"
+#include "fat.h"
 #endif
 
 // These bits of global data are used by the LCD and Keypad handler classes.
@@ -83,6 +84,11 @@ public:
       last_lcdrefresh = now;
       update_TEMPGRAPH();
       update_TEMP();
+
+#ifdef HAS_SD
+      update_SDSELECT();
+			update_MODS();
+#endif
       
 #ifdef HAS_KEYPAD
       update_MOTORS();
@@ -539,6 +545,8 @@ private:
     LCD.write((char)3);
     LCD.write((char)5);
     LCD.write((char)7);
+
+    tagline();
   }
 
 #ifdef HAS_KEYPAD
@@ -562,6 +570,13 @@ private:
     LCD.setCursor(9,2);
     LCD.label("STP:",MOTION.getAxis(MOD_AXIS).getStepsPerMM());
 
+    tagline();
+  }
+
+  void update_MODS()
+  {
+    if(currentmode != MODS)
+      return;
     tagline();
   }
 
@@ -761,6 +776,18 @@ private:
   {
     currentmode = SDSELECT;
     LCD.clear();
+    display_SDSELECT();
+  }
+
+  void update_SDSELECT()
+  {
+    if(currentmode != SDSELECT)
+      return;
+    tagline();
+  }
+
+  void display_SDSELECT()
+  {
 #ifdef HAS_SD    
     if(sdcard::isReading())
     {
@@ -796,7 +823,18 @@ private:
     if(lcd_y < 4)
       return;
     LCD.setCursor(0,3);
-    LCD.write_P(PSTR(LCD_TAGLINE));
+#ifdef HAS_SD
+    if(sdcard::isReading())
+    {
+      LCD.write_P(PSTR("SD Print: "));
+      LCD.write((uint16_t)(sdcard::getFilePos() * 100 / sdcard::getFileSize()));
+      LCD.write_P(PSTR("%"));
+		} else {
+#endif
+    	LCD.write_P(PSTR(LCD_TAGLINE));
+#ifdef HAS_SD
+		}
+#endif
   }
 
 };

--- a/LCDKeypad.h
+++ b/LCDKeypad.h
@@ -273,19 +273,35 @@ private:
         return true;
       case '2':
         t[G].setInt(1);
+#ifdef REVERSE_PRINTER
+        t[Y].setFloat(p[Y] + motordistance);
+#else
         t[Y].setFloat(p[Y] - motordistance);
+#endif
         break;
       case '8':
         t[G].setInt(1);
+#ifdef REVERSE_PRINTER
+        t[Y].setFloat(p[Y] - motordistance);
+#else
         t[Y].setFloat(p[Y] + motordistance);
+#endif
         break;
       case '4':
         t[G].setInt(1);
+#ifdef REVERSE_PRINTER
+        t[X].setFloat(p[X] + motordistance);
+#else
         t[X].setFloat(p[X] - motordistance);
+#endif
         break;
       case '6':
         t[G].setInt(1);
+#ifdef REVERSE_PRINTER
+        t[X].setFloat(p[X] - motordistance);
+#else
         t[X].setFloat(p[X] + motordistance);
+#endif
         break;
       case '3':
         t[G].setInt(1);

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ INCLUDE_SJFW_LOOKAHEAD = 1
 # EC for Gen3/4 only.  Others default to 100k Thermistors.
 USE_EXTRUDERCONTROLLER = 1
 
+# If the printer is position backwords (ie Y motor away form you on a prusa)
+#REVERSE_PRINTER = 1
+
 # "generic" is a special config with no pins defined.
 # You should be able to compile this for your chip, upload it, then configure the pins at
 # runtime.
@@ -85,13 +88,14 @@ ifeq ($(INCLUDE_SJFW_LOOKAHEAD),1)
   LOOK_FILES = 
   LOOK_DEFINES = -DLOOKAHEAD
 endif
-
-
+ifeq ($(REVERSE_PRINTER),1)
+  REVERSE_DEFINES = -DREVERSE_PRINTER
+endif
 
   
 
 EXTRA_FILES = $(MOTION_FILES) $(LCD_FILES) $(SD_FILES) $(BOARD_FILES) $(KEYPAD_FILES) $(BT_FILES) $(LOOK_FILES)
-EXTRA_DEFINES = $(MOTION_DEFINES) $(LCD_DEFINES) $(SD_DEFINES) $(BOARD_DEFINES) $(KEYPAD_DEFINES) $(BT_DEFINES) -DSJFW_VERSION='"$(SJFW_VERSION)"' $(LOOK_DEFINES)
+EXTRA_DEFINES = $(MOTION_DEFINES) $(LCD_DEFINES) $(SD_DEFINES) $(BOARD_DEFINES) $(KEYPAD_DEFINES) $(BT_DEFINES) -DSJFW_VERSION='"$(SJFW_VERSION)"' $(LOOK_DEFINES) $(REVERSE_DEFINES)
 
 
 

--- a/SDCard.cpp
+++ b/SDCard.cpp
@@ -329,5 +329,20 @@ bool printcurrent() {
   return true;
 }
 
+uint32_t getFilePos() {
+	if (playing)
+	{
+		return (uint32_t)file->pos;
+	}
+	return NULL;
+}
+
+uint32_t getFileSize() {
+	if (playing)
+	{
+		return (uint32_t)file->dir_entry.file_size;
+	}
+	return NULL;
+}
 
 } // namespace sdcard

--- a/SDCard.h
+++ b/SDCard.h
@@ -71,6 +71,11 @@ char const* getCurrentfile();
 // print currentfile
 bool printcurrent();
 
+// returns the current file position, null if not sd printing
+uint32_t  getFilePos();
+
+// returns the current file size, null if not sd printing
+uint32_t  getFileSize();
 
 /**************************/
 /** Read File             */

--- a/lib_sd/fat.cpp
+++ b/lib_sd/fat.cpp
@@ -161,16 +161,17 @@ struct fat_fs_struct
     cluster_t cluster_free;
 };
 
-struct fat_file_struct
-{
-    struct fat_fs_struct* fs;
-    struct fat_dir_entry_struct dir_entry;
-    offset_t pos;
-    cluster_t pos_cluster;
-#ifdef FAT_DELAY_DIRENTRY_UPDATE
-    uint8_t needs_write;
-#endif
-};
+// moved to fat.h (by tommyc)
+// struct fat_file_struct
+// {
+//     struct fat_fs_struct* fs;
+//     struct fat_dir_entry_struct dir_entry;
+//     offset_t pos;
+//     cluster_t pos_cluster;
+// #ifdef FAT_DELAY_DIRENTRY_UPDATE
+//     uint8_t needs_write;
+// #endif
+// };
 
 struct fat_dir_struct
 {

--- a/lib_sd/fat.h
+++ b/lib_sd/fat.h
@@ -89,6 +89,18 @@ struct fat_dir_entry_struct
     offset_t entry_offset;
 };
 
+
+struct fat_file_struct
+{
+    struct fat_fs_struct* fs;
+    struct fat_dir_entry_struct dir_entry;
+    offset_t pos;
+    cluster_t pos_cluster;
+#ifdef FAT_DELAY_DIRENTRY_UPDATE
+    uint8_t needs_write;
+#endif
+};
+
 struct fat_fs_struct* fat_open(struct partition_struct* partition);
 void fat_close(struct fat_fs_struct* fs);
 

--- a/lib_sd/sd_raw_config.h
+++ b/lib_sd/sd_raw_config.h
@@ -67,7 +67,7 @@ extern "C"
  * Set to 1 to support so-called SDHC memory cards, i.e. SD
  * cards with more than 2 gigabytes of memory.
  */
-#define SD_RAW_SDHC 0
+#define SD_RAW_SDHC 1
 
 /**
  * @}


### PR DESCRIPTION
3 commits each corresponds to one of the following

1) Enabling SDHC support
2) Added a compile time option to reverse X and Y movement when pressing the keypad.  Useful if the mendel is placed with the Y motor at the far side.
3) SD print progress, had to move fat_file_struct definition form fat.cpp to fat.h to expose the structure outside of the SD library.

Please let me know if you are happy with them.

tommy
