### PR TITLE
Fixed delay to work with newer avr-libc

### DIFF
--- a/Time.cpp
+++ b/Time.cpp
@@ -18,7 +18,8 @@ void init_time()
 
 void wait(unsigned long t)
 {
-  _delay_ms(t);
+	while(t--)
+  		_delay_ms(1);
 }    
 
 


### PR DESCRIPTION
newer avr-libc requires _delay_ms value to be compile time constant
