### PR TITLE
Sdcard fix for GcodeParser

### DIFF
--- a/GcodeQueue.cpp
+++ b/GcodeQueue.cpp
@@ -216,6 +216,7 @@ void GcodeQueue::parsebytes(char *bytes, uint8_t numbytes, uint8_t source)
 	long l;
 	errno = 0;
 
+#ifdef HAS_SD
 	// bytes should contain the filename
 	if (m23filename) {
 		m23filename = false;
@@ -232,7 +233,9 @@ void GcodeQueue::parsebytes(char *bytes, uint8_t numbytes, uint8_t source)
 			Host::Instance(source).endl();
 		}
 	}
-	else {
+	else 
+#endif
+	{
 		switch(bytes[0])
 		{
 			case 'N':

--- a/Time.cpp
+++ b/Time.cpp
@@ -18,7 +18,8 @@ void init_time()
 
 void wait(unsigned long t)
 {
-  _delay_ms(t);
+	while(t--)
+  		_delay_ms(1);
 }    
 
 


### PR DESCRIPTION
GcodeParser.cpp now compiles when HAS_SD is not defined
